### PR TITLE
add command line switch for custom mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ test-forward:
 test-graphics:
 	QEMU_OPTS="-sdl" $(NIXOS_SHELL) example-vm.nix
 
+test-mounts:
+	$(NIXOS_SHELL) example-vm.nix --mount $(shell realpath .) /mnt/nixos-shell
+
 install:
 	$(INSTALL) -D bin/nixos-shell $(DESTDIR)$(PREFIX)/bin/nixos-shell
 	$(INSTALL) -D share/nixos-shell/nixos-shell.nix $(DESTDIR)$(PREFIX)/share/nixos-shell/nixos-shell.nix

--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ This can be overridden by:
  networking.firewall.enable = lib.mkForce true;
 }
 ```
+
+## Mount directories
+
+To mount anywhere inside the virtual machine, use the `--mount` switch:
+
+```console
+$ nixos-shell --mount ./host-dir /guest-dir
+```

--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -10,10 +10,24 @@ if [[ -z "${QEMU_SHELL:-}" ]] && [[ -n "$SHELL" ]]; then
 fi
 
 nixos_config=vm.nix
-if [[ $# -gt 0 ]]; then
-  nixos_config=$1
-  shift
-fi
+declare -A mounts
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --)
+    shift
+    break
+    ;;
+  --mount)
+    mounts["$2"]="$3"
+    shift; shift; shift
+    ;;
+  *)
+    nixos_config="$1"
+    shift
+    ;;
+  esac
+done
+
 export QEMU_NIXOS_CONFIG=$(readlink -f "$nixos_config")
 
 export QEMU_OPTS="-m 500M -nographic -serial mon:stdio ${QEMU_OPTS:-}"
@@ -29,6 +43,18 @@ nix_profile="/nix/var/nix/profiles/per-user/${USER}/profile/"
 if [[ -d $nix_profile ]]; then
   export QEMU_OPTS="${QEMU_OPTS} -virtfs local,path=${nix_profile},security_model=none,mount_tag=nixprofile"
 fi
+
+for mount in ${!mounts[*]}; do
+  mount_tag=$(echo "$mount" | md5sum)
+  mount_tag=${mount_tag:0:31} # tags must be shorter than 32 bytes
+  mount_tag=${mount_tag/[0-9]/a} # tags must not begin with a digit
+
+  export QEMU_OPTS="${QEMU_OPTS} -virtfs local,path=${mount},security_model=none,mount_tag=${mount_tag}"
+
+  mounts[$mount_tag]="${mounts[$mount]}"
+  unset mounts["$mount"]
+done
+export _mounts="$(declare -p mounts)"
 
 nix-build '<nixpkgs/nixos>' -A vm -k \
   -I "nixos-config=${script_dir}/../share/nixos-shell/nixos-shell.nix" \


### PR DESCRIPTION
I need the ability to mount a given directory anywhere inside the VM. This PR adds a `--mount host-dir guest-dir` switch.

Note: This introduces a minor behavior change. Previously, all arguments after `vm.nix` were passed to `nix-build`. Now `--`  is required to stop argument parsing, so  
```console
nixos-shell vm.nix --arg …
```
becomes
```console
nixos-shell vm.nix -- --arg …
```