### PR TITLE
Prevent NIXOS_CONFIG to override nixos-shell conf

### DIFF
--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -19,6 +19,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 export QEMU_NIXOS_CONFIG="$(readlink -f "$nixos_config")"
+unset NIXOS_CONFIG
 
 tempdir=$(mktemp -d)
 cleanup() {


### PR DESCRIPTION
In NixOS systems where the system configuration is set through NIXOS_CONFIG environment variable the nixos-shell configuration is overriden and the system one is built instead.