### PR TITLE
Support `extendModules` for injecting nixos-shell's options and config modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test-mounts:
 test-efi:
 	$(NIXOS_SHELL) examples/vm-efi.nix
 
+test-broken:
+	! $(NIXOS_SHELL) --flake '.#BROKEN-DO-NOT-USE-UNLESS-YOU-KNOW-WHAT-YOU-ARE-DOING'
+
 install:
 	$(INSTALL) -D bin/nixos-shell $(DESTDIR)$(PREFIX)/bin/nixos-shell
 	$(INSTALL) -D share/modules/nixos-shell.nix $(DESTDIR)$(PREFIX)/share/modules/nixos-shell.nix

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ $ nixos-shell --flake github:Mic92/nixos-shell#vm-forward
 
 This will run the `vm-forward` example.
 
-> Note: system configurations have to be made overridable with `lib.makeOverridable` to use them with `nixos-shell`
+> Note: `nixos-shell` must be able to extend the specified system configuration with [certain modules](share/modules).
+>
+> If your version of `nixpkgs` provides the `extendModules` function on system configurations, `nixos-shell` will use it to inject the required modules; no additional work on your part is needed.
+>
+> If your version of `nixpkgs` **does not** provide `extendModules`, you must make your system configurations overridable with `lib.makeOverridable` to use them with `nixos-shell`:
 >```nix
 >{
 >  nixosConfigurations = let
@@ -51,6 +55,7 @@ This will run the `vm-forward` example.
 >  };
 >}
 >```
+> Specifying a non-overridable system configuration will cause `nixos-shell` to abort with a non-zero exit status.
 
 When using the `--flake` flag, if no attribute is given, `nixos-shell` tries the following flake output attributes:
 - `packages.<system>.nixosConfigurations.<vm>`

--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -65,7 +65,8 @@ if [[ -z "$flake_uri" ]]; then
   )
 else
   extraBuildFlags+=(
-     --extra-experimental-features "flakes"
+    --extra-experimental-features "flakes"
+    --argstr flakeStr "$flake"
     --argstr flakeUri "$flake_uri"
     --argstr flakeAttr "${flake_attr:-"vm"}"
   )

--- a/flake.nix
+++ b/flake.nix
@@ -18,13 +18,24 @@
 
     mkSystem = pkgs: config: makeOverridable nixosSystem {
       system = "x86_64-linux";
-      modules = [ config  inp.self.nixosModules.nixos-shell ];
+      modules = [ config inp.self.nixosModules.nixos-shell ];
     };
 
     supportedSystems = [ "x86_64-linux" ];
   in
   {
-    nixosConfigurations = mapAttrs (_name: config: mkSystem inp.nixpkgs config) vms;
+    nixosConfigurations =
+      let
+        configs = mapAttrs (_name: config: mkSystem inp.nixpkgs config) vms;
+      in
+      configs
+      //
+      {
+        # Used for testing that nixos-shell exits nonzero when provided a
+        # non-extensible config
+        BROKEN-DO-NOT-USE-UNLESS-YOU-KNOW-WHAT-YOU-ARE-DOING =
+          removeAttrs configs.vm [ "extendModules" "override" ];
+      };
 
     nixosModules.nixos-shell = import ./share/modules/nixos-shell.nix;
   }

--- a/share/nixos-shell.nix
+++ b/share/nixos-shell.nix
@@ -2,6 +2,7 @@
 , system ? builtins.currentSystem
 , configuration ? <nixos-config>
 
+, flakeStr ? null # flake as named on the command line
 , flakeUri ? null
 , flakeAttr ? null
 }:
@@ -42,8 +43,28 @@ if flakeUri != null then
   if flakeSystem != null then
     if flakeSystem ? "extendModules" then
       flakeSystem.extendModules { modules = nixosShellModules; }
-    else
+    else if flakeSystem ? "override" then
       flakeSystem.override (attrs: { modules = attrs.modules ++ nixosShellModules; })
+    else
+      throw ''
+          '${flakeStr}#${flakeAttr}' is missing the expected 'override' attribute.
+
+          Please ensure that '${flakeStr}#${flakeAttr}' is an overridable attribute set by declaring it with 'lib.makeOverridable'.
+
+          For instance:
+
+              nixosConfigurations = let
+                lib = nixpkgs.lib;
+              in {
+                "${flakeAttr}" = lib.makeOverridable lib.nixosSystem {
+                  # ...
+                };
+              };
+
+          Alternatively, upgrade to a version of nixpkgs that provides the 'extendModules' function on NixOS system configurations.
+
+          See https://github.com/Mic92/nixos-shell#start-a-virtual-machine for additional information.
+      ''
   else if flakeModule != null then
     mkShellSystem flakeModule
   else


### PR DESCRIPTION
This changeset makes it possible for folks on a recent-enough `nixpkgs` to use `nixos-shell` without declaring their system configs with `lib.makeOverridable`.  Basically, [this `nixos-generators` PR](https://github.com/nix-community/nixos-generators/pull/138), except:

1. This PR does not remove support for `nixpkgs` prior to the commit that introduced `extendModules`, and
2. This PR also adds code to issue a fairly detailed error message in case the caller provides a system config that lacks both the `override` and `extendModules` attributes.

Thank you for your consideration.