### PR TITLE
fix error on bad / unset $SHELL

### DIFF
--- a/share/modules/nixos-shell-config.nix
+++ b/share/modules/nixos-shell-config.nix
@@ -12,13 +12,12 @@ in {
 
       # fish seems to do funky stuff: https://github.com/Mic92/nixos-shell/issues/42
       shell = if shell' == "fish" then "bash" else shell';
-    in
-    lib.mkMerge [
       # Enable the module of the user's shell for some sensible defaults.
-      (lib.mkIf (options.programs ? ${shell}.enable && shell != "bash") {
+      maybeSetShell = lib.optional (options.programs ? ${shell}.enable && shell != "bash") {
         programs.${shell}.enable = mkVMDefault true;
-      })
-
+      };
+    in
+    lib.mkMerge (maybeSetShell ++ [
       (lib.mkIf (pkgs ? ${shell}) {
         users.extraUsers.root.shell = mkVMDefault pkgs.${shell};
       })
@@ -127,5 +126,5 @@ in {
 
         networking.firewall.enable = mkVMDefault false;
       }
-    ];
+    ]);
 }


### PR DESCRIPTION
`lib.mkIf` gets pushed down to the leaf while evaluating, so if you have an unknown shell as your `$SHELL` variable, it will error anyways.

To reproduce the bug:
```
SHELL=asdf nix run github:Mic92/nixos-shell -- --flake github:Mic92/nixos-shell#vm
```
And the error is:
```
error: The option `programs.asdf' does not exist. Definition values:
       - In `/nix/store/qanr0y6cgiy19rlb4zkiwg96cw6dng6h-nixos-shell/share/nixos-shell.nix':
           {
             _type = "if";
             condition = false;
             content = {
               enable = {
           ...
```

This PR fixes that.