### PR TITLE
Use flake.inputs.nixpkgs.lib if available, before defaulting to NIX_PATH

### DIFF
--- a/share/nixos-shell.nix
+++ b/share/nixos-shell.nix
@@ -6,7 +6,7 @@
 , flakeAttr ? null
 }:
 let
-  lib = (import nixpkgs { }).lib;
+  lib = flake.inputs.nixpkgs.lib or (import nixpkgs { }).lib;
 
   nixos-shell = import ./modules/nixos-shell.nix;
   nixos-shell-config = import ./modules/nixos-shell-config.nix;
@@ -15,7 +15,7 @@ let
 
   getFlakeOutput = path: lib.attrByPath path null flake.outputs;
 
-  mkShellSystem = config: import "${toString nixpkgs}/nixos/lib/eval-config.nix" {
+  mkShellSystem = config: import "${toString flake.inputs.nixpkgs or nixpkgs}/nixos/lib/eval-config.nix" {
     inherit system;
     modules = [
       config


### PR DESCRIPTION
If NIX_PATH is unset, nixos-shell would crash, even if flake inputs were available in the target nixosConfiguration, this commit fixes that by defaulting lib to the target flake's nixpkgs input

fixes https://github.com/Mic92/nixos-shell/issues/65