### PR TITLE
Fix bug introduced by 3e3dd034c8e2727d533915181222f4f31d37d201

### DIFF
--- a/share/nixos-shell.nix
+++ b/share/nixos-shell.nix
@@ -15,7 +15,7 @@ let
 
   getFlakeOutput = path: lib.attrByPath path null flake.outputs;
 
-  mkShellSystem = config: import "${toString flake.inputs.nixpkgs or nixpkgs}/nixos/lib/eval-config.nix" {
+  mkShellSystem = config: import "${if !(flakeUri == null) then (toString flake.inputs.nixpkgs) else (toString nixpkgs)}/nixos/lib/eval-config.nix" {
     inherit system;
     modules = [
       config


### PR DESCRIPTION
3e3dd034c8e2727d533915181222f4f31d37d201 broke the non-flake use case of just using a `vm.nix` with your `NIX_PATH` set. I can't think of a more elegant way to express this at the moment without a big refactor, which I don't want to implement.