### PR TITLE
bin/nixos-shell: use `nix run` to run; flake.nix: use `packages.<system>.default`

### DIFF
--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -53,27 +53,21 @@ done
 
 unset NIXOS_CONFIG
 
-tempdir=$(mktemp -d)
-cleanup() {
-  rm -rf "$tempdir"
-}
-trap cleanup EXIT SIGINT SIGQUIT ERR
-
 if [[ -z "$flake_uri" ]]; then
   extraBuildFlags+=(
     -I "nixos-config=$nixos_config"
   )
 else
   extraBuildFlags+=(
-    --extra-experimental-features "flakes"
+    --extra-experimental-features "nix-command flakes"
     --argstr flakeStr "$flake"
     --argstr flakeUri "$flake_uri"
     --argstr flakeAttr "${flake_attr:-"vm"}"
   )
 fi
 
-nix-build "${script_dir}/../share/nixos-shell.nix" -A "config.system.build.vm" -k \
-  -o "${tempdir}/result" \
-  "${extraBuildFlags[@]}"
+nix run config.system.build.vm \
+  --file "${script_dir}/../share/nixos-shell.nix" \
+  --keep-going \
+  "${extraBuildFlags[@]}" \
   "$@"
-"${tempdir}/result/bin/"run-*-vm

--- a/flake.nix
+++ b/flake.nix
@@ -42,13 +42,15 @@
 
   //
 
-  lib.foldl' lib.recursiveUpdate {} (lib.forEach supportedSystems (system: rec {
+  lib.foldl' lib.recursiveUpdate {} (lib.forEach supportedSystems (system: {
 
-    packages."${system}".nixos-shell = import ./default.nix {
-      pkgs = inp.nixpkgs.legacyPackages."${system}";
+    packages."${system}" = {
+      nixos-shell = import ./default.nix {
+        pkgs = inp.nixpkgs.legacyPackages."${system}";
+      };
+
+      default = inp.self.packages."${system}".nixos-shell;
     };
-
-    defaultPackage."${system}" = packages."${system}".nixos-shell;
 
   }));
 }


### PR DESCRIPTION
This PR is a collection of small refactoring.
*   bin/nixos-shell:
    * Use `nix run` to run the code instead of current `mktemp` hack.
    * Note that Nix 3.0 commands like `nix run` evaluates purely by default, contrary to Nix classic commands like `nix-build`.
* flake.nix:
    * Use `packages.<system>.default` instead of `defaultPackages.<system>`.
    * Recurse with `inp.self` instead of `rec`.