### PR TITLE
add support for foreigen guest-system

### DIFF
--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -14,7 +14,7 @@ usage() {
 vm.nix" 1>&2
 }
 
-nixos_config=vm.nix
+nixos_config=
 while [[ $# -gt 0 ]]; do
   i="$1"; shift 1
   case "$i" in
@@ -40,21 +40,35 @@ while [[ $# -gt 0 ]]; do
   --show-trace|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair|-L|--refresh|--no-net|--impure)
     extraBuildFlags+=("$i")
     ;;
+  --guest-system)
+    j="$1"; shift 1
+    extraBuildFlags+=("--argstr" "guestSystem" "$j")
+    ;;
+  --host-system)
+    j="$1"; shift 1
+    extraBuildFlags+=("--argstr" "hostSystem" "$j")
+    ;;
   --option)
     j="$1"; shift 1
     k="$1"; shift 1
     extraBuildFlags+=("$i" "$j" "$k")
     ;;
   *)
+    if [[ -n "$nixos_config" ]]; then
+      usage
+      exit 1
+    fi
     nixos_config="$i"
     ;;
   esac
 done
+nixos_config=${nixos_config:-vm.nix}
 
 unset NIXOS_CONFIG
 
 if [[ -z "$flake_uri" ]]; then
   extraBuildFlags+=(
+    --extra-experimental-features "nix-command"
     -I "nixos-config=$nixos_config"
   )
 else

--- a/share/modules/nixos-shell.nix
+++ b/share/modules/nixos-shell.nix
@@ -1,4 +1,4 @@
-{ lib, modulesPath, pkgs, extendModules, ... }:
+{ lib, pkgs, modulesPath, config, options, extendModules, ... }:
 
 {
   imports = [
@@ -15,13 +15,14 @@
     in {
       mountHome = mkOption {
         type = types.bool;
-        default = true;
-        description = "Whether to mount `/home`.";
+        default = builtins.getEnv "HOME" != "";
+        description = "Whether to mount `$HOME`.";
       };
 
       mountNixProfile = mkOption {
         type = types.bool;
-        default = true;
+        # if our host os does not match the guest os, binaries in our nix profile will not work
+        default = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform != pkgs.stdenv.hostPlatform;
         description = "Whether to mount the user's nix profile.";
       };
 


### PR DESCRIPTION
On macos this allows us the following:

./bin/nixos-shell --build-system aarch64-darwin --guest-system riscv64-linux examples/vm.nix

This is not doing any cross-compilation, meaning the host machine needs to have a remote builder setup.