### PR TITLE
shell config: only resize if on tty

### DIFF
--- a/share/modules/nixos-shell-config.nix
+++ b/share/modules/nixos-shell-config.nix
@@ -112,8 +112,8 @@ in {
               path = builtins.getEnv "PATH";
             in
             ''
-              # fix terminal size
-              eval "$(resize)"
+              # if terminal with stdout, fix terminal size
+              if [ -t 1 ]; then eval "$(resize)"; fi
 
               ${lib.optionalString (pwd != "") "cd '${pwd}' 2>/dev/null"}
               ${lib.optionalString (term != "") "export TERM='${term}'"}


### PR DESCRIPTION
Dear Mic92 (and other maintainers?),

when trying to spawn a VM for testing through nixos-shell, I encountered errors when invoking command through `ssh host COMMAND`. This always showed the message `resize:  can't open terminal /dev/tty` before the command output (which still ran successfully itself).

This is caused by an entry in `/etc/profile`, configured in [`share/modules/nixos-shell-config.nix`](https://github.com/Mic92/nixos-shell/blob/master/share/modules/nixos-shell-config.nix#L116), which calls `resize` indiscriminately. This PR adds a condition to the `resize` invocation to only call in TTYs.

To quote the commit message:

> Resize is only called if stdout is opened. This is checked through the test command. As it is not a shell builtin in all POSIX shells (although it is it is in bash), it is called from the coreutils packages using its full path. (The alternative of adding coreutils to the globally installed system packages might break setups.)
> 
> The previous configuration calls resize on any login shell through /etc/profile, which outputs an error messages on shells not on a tty. (That can occur when using ssh to call a command directly, i.e. `ssh host echo foo`).