### PR TITLE
fix missing executable run-nixos-vm

### DIFF
--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -89,4 +89,6 @@ nix build config.system.build.vm \
   --out-link "$TEMP_DIR/result" \
   "${extraBuildFlags[@]}"
 
-"$TEMP_DIR/result/bin/run-nixos-vm" "$@"
+# NixOS VMs use the machine name in the executable path. Rather than try to
+# figure it out here, we'll just use a wildcard
+"$TEMP_DIR"/result/bin/run-*-vm "$@"


### PR DESCRIPTION
I'm not sure how this hasn't made nixos-shell unusable for everyone. Please tell me if I'm just doing something wrong, but when I run `nixos-shell --flake .#blah` i get 

```
/nix/store/r6bsm8f7r7vjjradxzg44jg76yg1gsbd-nixos-shell/bin/.nixos-shell-wrapped: line 92: /tmp/nix-shell.ND6jWV/tmp.NTsDaycM05/result/bin/run-nixos-vm: No such file or directory
```

this is because the executable is named `run-<machine name>-vm`, not `run-nixos-vm`.