### PR TITLE
don't inherit PATH from host if the guest system != host system, add an option for it

### DIFF
--- a/share/modules/nixos-shell.nix
+++ b/share/modules/nixos-shell.nix
@@ -6,6 +6,12 @@
   ];
   
   options.nixos-shell = with lib; {
+    inheritPath = mkOption {
+      type = types.bool;
+      default = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform == pkgs.stdenv.hostPlatform;
+      description = "Whether to inherit the user's PATH.";
+    };
+
     mounts = let
       cache = mkOption {
         type = types.enum ["none" "loose" "fscache" "mmap"];


### PR DESCRIPTION
Same logic as we do elsewhere, surprised this didn't come up before.