### PR TITLE
Add option to fix broken terminfo detection on case insensitive FSes

### DIFF
--- a/share/modules/nixos-shell.nix
+++ b/share/modules/nixos-shell.nix
@@ -1,5 +1,8 @@
 { lib, pkgs, modulesPath, config, options, extendModules, ... }:
 
+let
+  isDarwin = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform.isDarwin;
+in
 {
   imports = [
     "${toString modulesPath}/virtualisation/qemu-vm.nix"
@@ -64,6 +67,15 @@
         );
         default = {};
       };
+    };
+
+    terminfo.fixFSCaseConflicts = mkOption {
+      type = types.bool;
+      default = isDarwin;
+      description = ''
+        Whether to apply workaround for broken terminfo lookup on hosts with case insensitive file
+        systems.
+      '';
     };
   };
 


### PR DESCRIPTION
Terminfo databases can become corrupted on macOS hosts due to the following reasons:

1. The ncurses package, responsible for most terminfo database files, contains entries that have case conflicts.
2. The Nix store is often backed by a case-insensitive file system on macOS.

Nix attempts to resolve these case conflicts by renaming the problematic files. However, this breaks terminal functionality since the affected terminfo entries become undetectable by software that uses them.

Example of affected directories:

```
# ls /run/current-system/sw/share/terminfo
1@  6@  a~nix~case~hack~1@  e~nix~case~hack~1@  j@                  m~nix~case~hack~1@  p~nix~case~hack~1@  t@  x~nix~case~hack~1@
2@  7@  b@                  f@                  k@                  N@                  Q@                  u@  z@
3@  8@  c@                  g@                  L@                  n~nix~case~hack~1@  q~nix~case~hack~1@  v@
4@  9@  d@                  h@                  l~nix~case~hack~1@  o@                  r@                  w@
5@  A@  E@                  i@                  M@                  P@                  s@                  X@
```

An example of the resulting error:

```
/etc/zprofile:30: can't find terminal definition for xterm-256color
```

To mitigate case conflicts, this PR makes the guest system copy terminfo entries from directories with lowercase letters to their uppercase counterparts. This ensures that when the Nix store is case-insensitive, access to `x/xterm-256color` will redirect to its copy, `X/xterm-256color`. Conversely, when the Nix store is case-sensitive, `x/xterm-256color` can still be accessed directly.

Closes #101 