### PR TITLE
Added readonly options to mountHome and extraMounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To mount anywhere inside the virtual machine, use the `nixos-shell.mounts.extraM
     "/var/www" = {
       target = ./src;
       cache = "none";
-      readme = true; # default is true
+      readOnly = true; # default is false
     };
   };
 }

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ To mount anywhere inside the virtual machine, use the `nixos-shell.mounts.extraM
     "/var/www" = {
       target = ./src;
       cache = "none";
+      readme = true; # default is true
     };
   };
 }

--- a/examples/vm-mounts.nix
+++ b/examples/vm-mounts.nix
@@ -5,6 +5,7 @@
     "/mnt/nixos-shell" = {
       target = ./..;
       cache = "none";
+      readOnly = true;
     };
   };
 }

--- a/share/modules/nixos-shell-config.nix
+++ b/share/modules/nixos-shell-config.nix
@@ -24,7 +24,7 @@ in {
       })
 
       (
-        lib.mkIf (home != "" && cfg.mounts.mountHome.enable) {
+        lib.mkIf (home != "" && cfg.mounts.mountHome) {
           users.extraUsers.root.home = lib.mkVMOverride home;
         }
       )
@@ -73,25 +73,25 @@ in {
               "-mon chardev=char0,mode=readline"
               "-device virtconsole,chardev=char0,nr=0"
             ] ++
-            lib.optional cfg.mounts.mountHome.enable "-virtfs local,path=${home},security_model=none,mount_tag=home,readonly=${if (cfg.mounts.mountHome.readonly) then "true" else "false"}" ++
-            lib.optional (cfg.mounts.mountNixProfile.enable && builtins.pathExists nixProfile) "-virtfs local,path=${nixProfile},security_model=none,mount_tag=nixprofile" ++
-            lib.mapAttrsToList (target: mount: "-virtfs local,path=${builtins.toString mount.target},security_model=none,mount_tag=${mount.tag},readonly=${if (mount.readonly) then "true" else "false"}") cfg.mounts.extraMounts;
+            lib.optional cfg.mounts.mountHome "-virtfs local,path=${home},security_model=none,mount_tag=home${lib.optionalString cfg.mounts.mountHomeReadOnly ",readonly=on"}" ++
+            lib.optional (cfg.mounts.mountNixProfile && builtins.pathExists nixProfile) "-virtfs local,path=${nixProfile},security_model=none,mount_tag=nixprofile" ++
+            lib.mapAttrsToList (target: mount: "-virtfs local,path=${builtins.toString mount.target},security_model=none,mount_tag=${mount.tag}${lib.optionalString mount.readOnly ",readonly=on"}") cfg.mounts.extraMounts;
         };
 
         # build-vm overrides our filesystem settings in nixos-config
         boot.initrd.postMountCommands =
-          (lib.optionalString cfg.mounts.mountHome.enable ''
+          (lib.optionalString cfg.mounts.mountHome ''
             mkdir -p $targetRoot/${lib.escapeShellArg home}
-            mount -t 9p home $targetRoot/${lib.escapeShellArg home} -o trans=virtio,version=9p2000.L,cache=${cfg.mounts.cache},msize=${toString config.virtualisation.msize}
+            mount -t 9p home $targetRoot/${lib.escapeShellArg home} -o trans=virtio,version=9p2000.L,cache=${cfg.mounts.cache},msize=${toString config.virtualisation.msize}${lib.optionalString cfg.mounts.mountHomeReadOnly ",ro"}
           '') +
-          (lib.optionalString (user != "" && cfg.mounts.mountNixProfile.enable) ''
+          (lib.optionalString (user != "" && cfg.mounts.mountNixProfile) ''
             mkdir -p $targetRoot/nix/var/nix/profiles/per-user/${user}/profile/
             mount -t 9p nixprofile $targetRoot/nix/var/nix/profiles/per-user/${user}/profile/ -o trans=virtio,version=9p2000.L,cache=${cfg.mounts.cache},msize=${toString config.virtualisation.msize}
           '') +
           builtins.concatStringsSep " " (lib.mapAttrsToList
             (target: mount: ''
               mkdir -p $targetRoot/${target}
-              mount -t 9p ${mount.tag} $targetRoot/${target} -o trans=virtio,version=9p2000.L,cache=${mount.cache},msize=${toString config.virtualisation.msize}
+              mount -t 9p ${mount.tag} $targetRoot/${target} -o trans=virtio,version=9p2000.L,cache=${mount.cache},msize=${toString config.virtualisation.msize}${lib.optionalString mount.readOnly ",ro"}
             '')
             cfg.mounts.extraMounts);
 

--- a/share/modules/nixos-shell-config.nix
+++ b/share/modules/nixos-shell-config.nix
@@ -24,7 +24,7 @@ in {
       })
 
       (
-        lib.mkIf (home != "" && cfg.mounts.mountHome) {
+        lib.mkIf (home != "" && cfg.mounts.mountHome.enable) {
           users.extraUsers.root.home = lib.mkVMOverride home;
         }
       )
@@ -73,18 +73,18 @@ in {
               "-mon chardev=char0,mode=readline"
               "-device virtconsole,chardev=char0,nr=0"
             ] ++
-            lib.optional cfg.mounts.mountHome "-virtfs local,path=${home},security_model=none,mount_tag=home" ++
-            lib.optional (cfg.mounts.mountNixProfile && builtins.pathExists nixProfile) "-virtfs local,path=${nixProfile},security_model=none,mount_tag=nixprofile" ++
-            lib.mapAttrsToList (target: mount: "-virtfs local,path=${builtins.toString mount.target},security_model=none,mount_tag=${mount.tag}") cfg.mounts.extraMounts;
+            lib.optional cfg.mounts.mountHome.enable "-virtfs local,path=${home},security_model=none,mount_tag=home,readonly=${if (cfg.mounts.mountHome.readonly) then "true" else "false"}" ++
+            lib.optional (cfg.mounts.mountNixProfile.enable && builtins.pathExists nixProfile) "-virtfs local,path=${nixProfile},security_model=none,mount_tag=nixprofile" ++
+            lib.mapAttrsToList (target: mount: "-virtfs local,path=${builtins.toString mount.target},security_model=none,mount_tag=${mount.tag},readonly=${if (mount.readonly) then "true" else "false"}") cfg.mounts.extraMounts;
         };
 
         # build-vm overrides our filesystem settings in nixos-config
         boot.initrd.postMountCommands =
-          (lib.optionalString cfg.mounts.mountHome ''
+          (lib.optionalString cfg.mounts.mountHome.enable ''
             mkdir -p $targetRoot/${lib.escapeShellArg home}
             mount -t 9p home $targetRoot/${lib.escapeShellArg home} -o trans=virtio,version=9p2000.L,cache=${cfg.mounts.cache},msize=${toString config.virtualisation.msize}
           '') +
-          (lib.optionalString (user != "" && cfg.mounts.mountNixProfile) ''
+          (lib.optionalString (user != "" && cfg.mounts.mountNixProfile.enable) ''
             mkdir -p $targetRoot/nix/var/nix/profiles/per-user/${user}/profile/
             mount -t 9p nixprofile $targetRoot/nix/var/nix/profiles/per-user/${user}/profile/ -o trans=virtio,version=9p2000.L,cache=${cfg.mounts.cache},msize=${toString config.virtualisation.msize}
           '') +

--- a/share/modules/nixos-shell.nix
+++ b/share/modules/nixos-shell.nix
@@ -19,17 +19,27 @@
         description = "9p caching policy";
       };
     in {
-      mountHome = mkOption {
-        type = types.bool;
-        default = builtins.getEnv "HOME" != "";
-        description = "Whether to mount `$HOME`.";
+      mountHome = { 
+        enable = mkOption {
+          type = types.bool;
+          default = builtins.getEnv "HOME" != "";
+          description = "Whether to mount `$HOME`.";
+        };
+        readonly = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Mount `$HOME` as readonly.";
+          };
       };
 
-      mountNixProfile = mkOption {
-        type = types.bool;
-        # if our host os does not match the guest os, binaries in our nix profile will not work
-        default = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform == pkgs.stdenv.hostPlatform;
-        description = "Whether to mount the user's nix profile.";
+      mountNixProfile = {
+        enable = mkOption {
+          type = types.bool;
+          # if our host os does not match the guest os, binaries in our nix profile will not work
+          default = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform == pkgs.stdenv.hostPlatform;
+          description = "Whether to mount the user's nix profile.";
+          # The nix store is by default readonly so no need for an extra option 
+        };
       };
 
       inherit cache;
@@ -52,6 +62,11 @@
                 type = types.str;
                 internal = true;
               };
+              readonly = mkOption {
+                  type = types.bool;
+                  default = false;
+                  description = "Mount path as readonly.";
+                };
             };
 
             config.tag = lib.mkDefault (

--- a/share/modules/nixos-shell.nix
+++ b/share/modules/nixos-shell.nix
@@ -19,27 +19,23 @@
         description = "9p caching policy";
       };
     in {
-      mountHome = { 
-        enable = mkOption {
-          type = types.bool;
-          default = builtins.getEnv "HOME" != "";
-          description = "Whether to mount `$HOME`.";
-        };
-        readonly = mkOption {
-            type = types.bool;
-            default = false;
-            description = "Mount `$HOME` as readonly.";
-          };
+      mountHome = mkOption {
+        type = types.bool;
+        default = builtins.getEnv "HOME" != "";
+        description = "Whether to mount `$HOME`.";
       };
 
-      mountNixProfile = {
-        enable = mkOption {
-          type = types.bool;
-          # if our host os does not match the guest os, binaries in our nix profile will not work
-          default = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform == pkgs.stdenv.hostPlatform;
-          description = "Whether to mount the user's nix profile.";
-          # The nix store is by default readonly so no need for an extra option 
-        };
+      mountHomeReadOnly = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Mount `$HOME` read-only inside the VM.";
+      };
+
+      mountNixProfile = mkOption {
+        type = types.bool;
+        # if our host os does not match the guest os, binaries in our nix profile will not work
+        default = options.virtualisation.host.pkgs.isDefined && config.virtualisation.host.pkgs.stdenv.hostPlatform == pkgs.stdenv.hostPlatform;
+        description = "Whether to mount the user's nix profile.";
       };
 
       inherit cache;
@@ -62,11 +58,11 @@
                 type = types.str;
                 internal = true;
               };
-              readonly = mkOption {
-                  type = types.bool;
-                  default = false;
-                  description = "Mount path as readonly.";
-                };
+              readOnly = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Mount path read-only inside the VM.";
+              };
             };
 
             config.tag = lib.mkDefault (


### PR DESCRIPTION
This PR seeks to add readonly options to mountHome and extraMounts. 
The conditional for interpolating the readonly value into the virtfs argument looks a bit messy, so can be changed to a better option.