### PR TITLE
Allow the passing of extra modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ If an attribute _name_ is given, `nixos-shell` tries the following flake output 
 - `nixosConfigurations.<name>`
 - `nixosModules.<name>`
 
+You can extend a VM definition by passing the `--extra-module` flag to layer a local module on top of a flake-defined base configuration:
+
+```console
+$ nixos-shell --flake github:Mic92/nixos-shell#vm --extra-module ./project.nix
+```
+
+You can pass `--extra-module` multiple times to include several modules:
+
+```console
+$ nixos-shell --flake github:Mic92/nixos-shell#vm --extra-module ./project.nix --extra-module ./private.nix
+```
+
+The flag works equally well without `--flake`, letting you extend a plain `vm.nix` with additional modules:
+
+```console
+$ nixos-shell vm.nix --extra-module ./private.nix
+```
 
 ## Terminating the virtual machine
 

--- a/bin/nixos-shell
+++ b/bin/nixos-shell
@@ -13,13 +13,14 @@ usage() {
 [--impure] [--keep-going | -k] [--keep-failed | -K]
 [--no-net] [--option name value] [--repair]
 [--refresh] [--show-trace] [--verbose | -v | -vv | -vvv | -vvvv | -vvvvv]
-[--build-only] [--] [nixos-config]
+[--build-only] [--extra-module path] [--] [nixos-config]
 [--out-link link]
 
 vm.nix" 1>&2
 }
 
 nixos_config=
+extra_modules=()
 while [[ $# -gt 0 ]]; do
   i="$1"; shift 1
   case "$i" in
@@ -65,6 +66,10 @@ while [[ $# -gt 0 ]]; do
     out_link="$1";
     shift 1
     ;;
+  --extra-module)
+    j="$1"; shift 1
+    extra_modules+=("$(realpath "$j")")
+    ;;
   *)
     if [[ -n "$nixos_config" ]]; then
       usage
@@ -78,10 +83,17 @@ nixos_config=${nixos_config:-vm.nix}
 
 unset NIXOS_CONFIG
 
+extra_modules_list="["
+for module in "${extra_modules[@]}"; do
+  extra_modules_list+=" \"$module\""
+done
+extra_modules_list+=" ]"
+
 if [[ -z "$flake_uri" ]]; then
   extraBuildFlags+=(
     --extra-experimental-features "nix-command"
     -I "nixos-config=$nixos_config"
+    --arg extraModules "$extra_modules_list"
   )
 else
   extraBuildFlags+=(
@@ -89,6 +101,7 @@ else
     --argstr flakeStr "$flake"
     --argstr flakeUri "$flake_uri"
     --argstr flakeAttr "${flake_attr:-"vm"}"
+    --arg extraModules "$extra_modules_list"
   )
 fi
 

--- a/share/nixos-shell.nix
+++ b/share/nixos-shell.nix
@@ -5,6 +5,7 @@
 , flakeStr ? null # flake as named on the command line
 , flakeUri ? null
 , flakeAttr ? null
+, extraModules ? [ ]
 }:
 let
   hasFlake = flakeUri != null;
@@ -21,7 +22,7 @@ let
     })
     ./modules/nixos-shell.nix
     ./modules/nixos-shell-config.nix
-  ];
+  ] ++ extraModules;
 
   nixpkgsPath = if hasFlakeNixpkgs then
     flake.inputs.nixpkgs


### PR DESCRIPTION
Allows the composing of multiple configurations, primarily so I can have a base VM defined in my system flake, which I can then extend with project specific configurations.

So I can have my cake and eat it too.